### PR TITLE
Removed redundant ResourceDefinitions null check

### DIFF
--- a/csharp/src/ResourceDefinitions.cs
+++ b/csharp/src/ResourceDefinitions.cs
@@ -30,10 +30,6 @@ namespace csharp
 
         public static ResourceDefinitions getInstance()
         {
-            if (resourceDefinitions == null)
-            {
-                resourceDefinitions = new ResourceDefinitions();
-            }
             return resourceDefinitions;
         }
         /// <summary>


### PR DESCRIPTION
The singleton `resourceDefinitions` is initialized at type construction time and so will never be null bey the time `getInstance` is called. This Change removes the redundant null check. On glancing at the original code it looked like a potential race condition with multiple possible  instances being created.

Note that this pattern is repeated elsewhere, but I'm testing the water with this PR to see if you folks are open to community help before I put any more effort in.